### PR TITLE
refactor: PostService에서 좋아요 수/상태 조회 로직 PostLikeService로 분리

### DIFF
--- a/wannago-server/src/main/java/com/wannago/post/controller/PostLikeController.java
+++ b/wannago-server/src/main/java/com/wannago/post/controller/PostLikeController.java
@@ -16,7 +16,7 @@ public class PostLikeController {
 
     private final PostLikeService postLikeService;
 
-    // 단일 게시글에 대한 좋아요 수 & 좋아요 상태 조회 (로그인 없이 테스트 용도)
+    // 단일 게시글에 대한 좋아요 수 & 좋아요 상태 조회
     @GetMapping("/{postId}/like")
     public ResponseEntity<Map<String, Object>> getPostLikeInfoWithoutLogin(
             @PathVariable Long postId,
@@ -34,7 +34,6 @@ public class PostLikeController {
 
     // 좋아요 토글 요청 (좋아요 등록/취소)
     @PostMapping("/{postId}/like")
-    // 로그인 기능 구현 없는 상태 => 좋아요 API 테스트 용 임시 메서드
     public ResponseEntity<Map<String, Boolean>> toggleLikeWithoutLogin(
             @PathVariable Long postId,
             @RequestParam(required = false) Long memberId // 쿼리 파라미터로 강제 전달 /like?memberId=5
@@ -42,35 +41,6 @@ public class PostLikeController {
         boolean liked = postLikeService.toggleLike(postId, memberId);
         return ResponseEntity.ok(Map.of("liked", liked));
     }
-    // @PostMapping("/{postId}/like")
-//    public ResponseEntity<Map<String, Boolean>> toggleLike(
-//            @PathVariable Long postId,
-//            @AuthenticationPrincipal LoginUser loginUser
-//    ) {
-//        if (loginUser == null) { // 로그인
-//            return ResponseEntity.status(401).body(Map.of("liked", false));
-//        }
-//
-//        boolean liked = postLikeService.toggleLike(postId, loginUser.getId());
-//        return ResponseEntity.ok(Map.of("liked", liked));
-//    }
 
-    // 전체 게시글 정보 + 좋아요 수 & 좋아요 상태 조회
-    // 로그인 기능 구현 없는 상태 => 좋아요 API 테스트 용 임시 메서드
-    @GetMapping("/like")
-    public ResponseEntity<PostsResponse> getAllPostsWithLikeInfoWithoutLogin(
-            @RequestParam(required = false) Long memberId // /like?memberId=5
-    ) {
-        PostsResponse response = postLikeService.getAllPostsWithLikeInfo(memberId);
-        return ResponseEntity.ok(response);
-    }
-//    @GetMapping("/with-likes")
-//    public ResponseEntity<PostsResponse> getAllPostsWithLikeInfo(
-//            @AuthenticationPrincipal LoginUser loginUser
-//    ) {
-//        Long memberId = loginUser != null ? loginUser.getId() : null;
-//        PostsResponse response = postLikeService.getAllPostsWithLikeInfo(memberId);
-//        return ResponseEntity.ok(response);
-//    }
 }
 

--- a/wannago-server/src/main/java/com/wannago/post/dto/PostLikeCount.java
+++ b/wannago-server/src/main/java/com/wannago/post/dto/PostLikeCount.java
@@ -1,6 +1,6 @@
 package com.wannago.post.dto;
 
-// dto 프로젝션: 필요한 필드만 담은 인터페이스나 클래스를 만들어서, 쿼리 결과를 거기에 바로 매핑
+// dto 프로젝션: 필요한 필드만 담은 인터페이스나 클래스를 만들어서, 쿼리 결과를 거기에 바로 매핑 (집계용)
 public interface PostLikeCount {
     Long getPostId();
     Long getLikeCount();

--- a/wannago-server/src/main/java/com/wannago/post/service/PostLikeService.java
+++ b/wannago-server/src/main/java/com/wannago/post/service/PostLikeService.java
@@ -3,6 +3,9 @@ package com.wannago.post.service;
 import com.wannago.member.entity.Member;
 import com.wannago.post.dto.PostsResponse;
 
+import java.util.List;
+import java.util.Map;
+
 public interface PostLikeService {
     // 좋아요/취소
     boolean toggleLike(Long postId, Long memberId);
@@ -10,6 +13,6 @@ public interface PostLikeService {
     int getLikeCount(Long postId);
     // 개별 게시글 좋아요 여부
     boolean hasLiked(Long postId, Long memberId);
-    // Posts 목록 전체에 대해 likeCount/liked 같이 조회
-    PostsResponse getAllPostsWithLikeInfo(Long memberId);
+    Map<Long, Integer> getLikeCountMap(List<Long> postIds);
+    Map<Long, Boolean> getLikedMap(List<Long> postIds, Long memberId);
 }

--- a/wannago-server/src/main/java/com/wannago/post/service/PostLikeServiceImpl.java
+++ b/wannago-server/src/main/java/com/wannago/post/service/PostLikeServiceImpl.java
@@ -76,45 +76,51 @@ public class PostLikeServiceImpl implements PostLikeService {
                 .orElseThrow(() -> new CustomException(MEMBER_NOT_EXIST));
         return postLikeRepository.existsByPostAndMember(post, member);
     }
-
-    // 전체 게시글에 대한 좋아요 정보 함께 응답
+    // 게시글별 좋아요 수 Map 반환
     @Override
-    public PostsResponse getAllPostsWithLikeInfo(Long memberId) {
-        // 전체 게시글 목록 가져오기
-        List<Post> posts = postRepository.findAll();
-        // 그 게시글들의 ID만 추출해서 리스트 만듦
-        List<Long> postIds = posts.stream().map(Post::getId).toList();
-
-        // 전체 게시글의 좋아요 수 추출한 리스트 생성
+    public Map<Long, Integer> getLikeCountMap(List<Long> postIds) {
         List<PostLikeCount> counts = postLikeRepository.countLikesByPostIds(postIds);
-        // 전체 게시글 ID와 그에 해당하는 좋아요 수를 매핑할 Map 생성
+
         Map<Long, Integer> likeCountMap = new HashMap<>();
-        // 맵에 게시글 id와 좋아요 수 값을 넣음
-        for (PostLikeCount plc : counts) {
-            likeCountMap.put(plc.getPostId(), plc.getLikeCount().intValue());
+        for (PostLikeCount count : counts) {
+            likeCountMap.put(count.getPostId(), count.getLikeCount().intValue());
         }
 
-        // 현재 로그인한 사용자가 전체 게시글에 대하여 좋아요 눌렀는지 여부를 매핑한 map
+        // postIds에 없는 게시글은 기본값 0으로 넣어줌
+        for (Long postId : postIds) {
+            likeCountMap.putIfAbsent(postId, 0);
+        }
+
+        return likeCountMap;
+    }
+
+    // 사용자의 게시글별 좋아요 여부 Map 반환
+    @Override
+    public Map<Long, Boolean> getLikedMap(List<Long> postIds, Long memberId) {
         Map<Long, Boolean> likedMap = new HashMap<>();
-        //로그인한 상태
-        if (memberId != null) {
-            // 사용자 유효성 검증
-            Member member = memberRepository.findById(memberId)
-                    .orElseThrow(() -> new CustomException(MEMBER_NOT_EXIST));
-            // 해당 유저가 좋아요 누른 게시물의 좋아요 객체들의 리스트
-            List<PostLike> likes = postLikeRepository.findByPostIdInAndMember(postIds, member);
-            // likedMap에 사용자 ID와 좋아요 등록 boolean 값을 넣음
-            for (PostLike like : likes) {
-                likedMap.put(like.getPost().getId(), true);
+
+        // 로그인하지 않은 경우 모두 false 처리
+        if (memberId == null) {
+            for (Long postId : postIds) {
+                likedMap.put(postId, false);
             }
+            return likedMap;
         }
-        // 로그인 안 한 상태
-        else {
-            for (Long id : postIds) {
-                likedMap.put(id, false); // 로그인 안했으니 아무것도 누른적 없다고 설정
-            }
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new CustomException(MEMBER_NOT_EXIST));
+
+        List<PostLike> likedPosts = postLikeRepository.findByPostIdInAndMember(postIds, member);
+
+        for (PostLike like : likedPosts) {
+            likedMap.put(like.getPost().getId(), true);
         }
-        // 응답 DTO 리스트로 전달
-        return postMapper.getPostsResponse(posts, likeCountMap, likedMap);
+
+        // 나머지는 false 처리
+        for (Long postId : postIds) {
+            likedMap.putIfAbsent(postId, false);
+        }
+
+        return likedMap;
     }
 }


### PR DESCRIPTION
PostServiceImpl 내부에 있던 게시글별 좋아요 수 및 상태 조회 로직을
전담 서비스인 PostLikeService로 분리하여 관심사 분리 및 재사용성 향상
- getAllPostsWithLikeInfo 메서드 -> getLikeCountMap, getLikedMap 시그니쳐 메서드로 분리
- **PostServiceImpl의 getAllPostsWithStatusInfo에서 사용됨**
