### PR TITLE
refactor: 중복 로직 제거, 인증 객체 적용 #3

### DIFF
--- a/wannago-server/src/main/java/com/wannago/post/controller/PostLikeController.java
+++ b/wannago-server/src/main/java/com/wannago/post/controller/PostLikeController.java
@@ -16,7 +16,7 @@ public class PostLikeController {
 
     private final PostLikeService postLikeService;
 
-    // 단일 게시글에 대한 좋아요 수 & 좋아요 상태 조회 (로그인 없이 테스트 용도)
+    // 단일 게시글에 대한 좋아요 수 & 좋아요 상태 조회
     @GetMapping("/{postId}/like")
     public ResponseEntity<Map<String, Object>> getPostLikeInfoWithoutLogin(
             @PathVariable Long postId,
@@ -34,7 +34,6 @@ public class PostLikeController {
 
     // 좋아요 토글 요청 (좋아요 등록/취소)
     @PostMapping("/{postId}/like")
-    // 로그인 기능 구현 없는 상태 => 좋아요 API 테스트 용 임시 메서드
     public ResponseEntity<Map<String, Boolean>> toggleLikeWithoutLogin(
             @PathVariable Long postId,
             @RequestParam(required = false) Long memberId // 쿼리 파라미터로 강제 전달 /like?memberId=5
@@ -42,35 +41,6 @@ public class PostLikeController {
         boolean liked = postLikeService.toggleLike(postId, memberId);
         return ResponseEntity.ok(Map.of("liked", liked));
     }
-    // @PostMapping("/{postId}/like")
-//    public ResponseEntity<Map<String, Boolean>> toggleLike(
-//            @PathVariable Long postId,
-//            @AuthenticationPrincipal LoginUser loginUser
-//    ) {
-//        if (loginUser == null) { // 로그인
-//            return ResponseEntity.status(401).body(Map.of("liked", false));
-//        }
-//
-//        boolean liked = postLikeService.toggleLike(postId, loginUser.getId());
-//        return ResponseEntity.ok(Map.of("liked", liked));
-//    }
 
-    // 전체 게시글 정보 + 좋아요 수 & 좋아요 상태 조회
-    // 로그인 기능 구현 없는 상태 => 좋아요 API 테스트 용 임시 메서드
-    @GetMapping("/like")
-    public ResponseEntity<PostsResponse> getAllPostsWithLikeInfoWithoutLogin(
-            @RequestParam(required = false) Long memberId // /like?memberId=5
-    ) {
-        PostsResponse response = postLikeService.getAllPostsWithLikeInfo(memberId);
-        return ResponseEntity.ok(response);
-    }
-//    @GetMapping("/with-likes")
-//    public ResponseEntity<PostsResponse> getAllPostsWithLikeInfo(
-//            @AuthenticationPrincipal LoginUser loginUser
-//    ) {
-//        Long memberId = loginUser != null ? loginUser.getId() : null;
-//        PostsResponse response = postLikeService.getAllPostsWithLikeInfo(memberId);
-//        return ResponseEntity.ok(response);
-//    }
 }
 

--- a/wannago-server/src/main/java/com/wannago/post/controller/PostLikeController.java
+++ b/wannago-server/src/main/java/com/wannago/post/controller/PostLikeController.java
@@ -1,10 +1,12 @@
 package com.wannago.post.controller;
 
 // import com.wannago.auth.LoginUser; // ← auth? 구현되면
+import com.wannago.member.entity.Member;
 import com.wannago.post.service.PostLikeService;
 import com.wannago.post.dto.PostsResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
@@ -18,12 +20,12 @@ public class PostLikeController {
 
     // 단일 게시글에 대한 좋아요 수 & 좋아요 상태 조회
     @GetMapping("/{postId}/like")
-    public ResponseEntity<Map<String, Object>> getPostLikeInfoWithoutLogin(
+    public ResponseEntity<Map<String, Object>> getLikeInfo(
             @PathVariable Long postId,
-            @RequestParam(required = false) Long memberId
+            @AuthenticationPrincipal Member member
     ) {
         int likeCount = postLikeService.getLikeCount(postId);
-        boolean liked = memberId != null && postLikeService.hasLiked(memberId, postId);
+        boolean liked = member != null && postLikeService.hasLiked(postId,member);
 
         return ResponseEntity.ok(Map.of(
                 "postId", postId,
@@ -34,11 +36,11 @@ public class PostLikeController {
 
     // 좋아요 토글 요청 (좋아요 등록/취소)
     @PostMapping("/{postId}/like")
-    public ResponseEntity<Map<String, Boolean>> toggleLikeWithoutLogin(
+    public ResponseEntity<Map<String, Boolean>> toggleLike(
             @PathVariable Long postId,
-            @RequestParam(required = false) Long memberId // 쿼리 파라미터로 강제 전달 /like?memberId=5
+            @AuthenticationPrincipal Member member
     ) {
-        boolean liked = postLikeService.toggleLike(postId, memberId);
+        boolean liked = postLikeService.toggleLike(postId, member);
         return ResponseEntity.ok(Map.of("liked", liked));
     }
 

--- a/wannago-server/src/main/java/com/wannago/post/dto/PostLikeCount.java
+++ b/wannago-server/src/main/java/com/wannago/post/dto/PostLikeCount.java
@@ -1,6 +1,6 @@
 package com.wannago.post.dto;
 
-// dto 프로젝션: 필요한 필드만 담은 인터페이스나 클래스를 만들어서, 쿼리 결과를 거기에 바로 매핑
+// dto 프로젝션: 필요한 필드만 담은 인터페이스나 클래스를 만들어서, 쿼리 결과를 거기에 바로 매핑 (집계용)
 public interface PostLikeCount {
     Long getPostId();
     Long getLikeCount();

--- a/wannago-server/src/main/java/com/wannago/post/service/PostLikeService.java
+++ b/wannago-server/src/main/java/com/wannago/post/service/PostLikeService.java
@@ -8,11 +8,13 @@ import java.util.Map;
 
 public interface PostLikeService {
     // 좋아요/취소
-    boolean toggleLike(Long postId, Long memberId);
+    boolean toggleLike(Long postId, Member member);
     // 개별 게시글 좋아요 수
     int getLikeCount(Long postId);
     // 개별 게시글 좋아요 여부
-    boolean hasLiked(Long postId, Long memberId);
+    boolean hasLiked(Long postId, Member member);
+    // 게시글별 좋아요 수 Map 반환
     Map<Long, Integer> getLikeCountMap(List<Long> postIds);
-    Map<Long, Boolean> getLikedMap(List<Long> postIds, Long memberId);
+    // 게시글별 좋아요 여부 Map 반환
+    Map<Long, Boolean> getLikedMap(List<Long> postIds, Member member);
 }

--- a/wannago-server/src/main/java/com/wannago/post/service/PostLikeService.java
+++ b/wannago-server/src/main/java/com/wannago/post/service/PostLikeService.java
@@ -3,6 +3,9 @@ package com.wannago.post.service;
 import com.wannago.member.entity.Member;
 import com.wannago.post.dto.PostsResponse;
 
+import java.util.List;
+import java.util.Map;
+
 public interface PostLikeService {
     // 좋아요/취소
     boolean toggleLike(Long postId, Long memberId);
@@ -10,6 +13,6 @@ public interface PostLikeService {
     int getLikeCount(Long postId);
     // 개별 게시글 좋아요 여부
     boolean hasLiked(Long postId, Long memberId);
-    // Posts 목록 전체에 대해 likeCount/liked 같이 조회
-    PostsResponse getAllPostsWithLikeInfo(Long memberId);
+    Map<Long, Integer> getLikeCountMap(List<Long> postIds);
+    Map<Long, Boolean> getLikedMap(List<Long> postIds, Long memberId);
 }

--- a/wannago-server/src/main/java/com/wannago/post/service/PostLikeServiceImpl.java
+++ b/wannago-server/src/main/java/com/wannago/post/service/PostLikeServiceImpl.java
@@ -2,9 +2,7 @@ package com.wannago.post.service;
 
 import com.wannago.common.exception.CustomException;
 import com.wannago.member.entity.Member;
-import com.wannago.member.repository.MemberRepository;
 import com.wannago.post.dto.PostLikeCount;
-import com.wannago.post.dto.PostsResponse;
 import com.wannago.post.entity.Post;
 import com.wannago.post.entity.PostLike;
 import com.wannago.post.repository.PostLikeRepository;
@@ -29,53 +27,40 @@ public class PostLikeServiceImpl implements PostLikeService {
     //생성자 주입(@RequiredArgsConstructor)
     private final PostLikeRepository postLikeRepository;
     private final PostRepository postRepository;
-    private final MemberRepository memberRepository;
     private final PostMapper postMapper;
 
     // 좋아요 토글 기능: 게시글에 대한 사용자의 좋아요 상태를 반대로 전환
     @Override
     @Transactional
-    public boolean toggleLike(Long postId, Long memberId) {
-        // 게시글 유효성 검증
-        Post post = postRepository.findById(postId)
-                .orElseThrow(() -> new CustomException(POST_NOT_FOUND));
-        // 사용자 유효성 검증
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new CustomException(MEMBER_NOT_EXIST));
-        // Optinal로 좋아요 존재 확인
-        Optional<PostLike> like = postLikeRepository.findByPostAndMember(post, member);
+    public boolean toggleLike(Long postId, Member member) {
+        Post post = getPostOrThrow(postId);
 
-        // 좋아요 누른 상태라면 => 좋아요 해제
-        if (like.isPresent()) {
-            postLikeRepository.delete(like.get());
-            return false;
-        }
-        // 안누른 상태라면 => 좋아요 등록
-            postLikeRepository.save(new PostLike(null, post, member));
-            return true;
-
+        return postLikeRepository.findByPostAndMember(post, member)
+                // 좋아요 누른 상태라면 => 좋아요 해제
+                .map(existing -> {
+                    postLikeRepository.delete(existing);
+                    return false;
+                })
+                // 안누른 상태라면 => 좋아요 등록
+                .orElseGet(() -> {
+                    postLikeRepository.save(new PostLike(null, post, member));
+                    return true;
+                });
     }
 
     // 단일 게시글의 총 좋아요 수 조회
+
     @Override
     public int getLikeCount(Long postId) {
-        // 게시글 유효성 검증
-        Post post = postRepository.findById(postId)
-                .orElseThrow(() -> new CustomException(POST_NOT_FOUND));
-        return postLikeRepository.countByPost(post);
+        return postLikeRepository.countByPost(getPostOrThrow(postId));
     }
 
     // 사용자가 해당 게시글에 좋아요 눌렀는지 빠르게 확인
     @Override
-    public boolean hasLiked(Long postId, Long memberId) {
-        // 게시글 유효성 검증
-        Post post = postRepository.findById(postId)
-                .orElseThrow(() -> new CustomException(POST_NOT_FOUND));
-        // 사용자 유효성 검증
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new CustomException(MEMBER_NOT_EXIST));
-        return postLikeRepository.existsByPostAndMember(post, member);
+    public boolean hasLiked(Long postId, Member member) {
+        return postLikeRepository.existsByPostAndMember(getPostOrThrow(postId), member);
     }
+
     // 게시글별 좋아요 수 Map 반환
     @Override
     public Map<Long, Integer> getLikeCountMap(List<Long> postIds) {
@@ -96,19 +81,16 @@ public class PostLikeServiceImpl implements PostLikeService {
 
     // 사용자의 게시글별 좋아요 여부 Map 반환
     @Override
-    public Map<Long, Boolean> getLikedMap(List<Long> postIds, Long memberId) {
+    public Map<Long, Boolean> getLikedMap(List<Long> postIds, Member member) {
         Map<Long, Boolean> likedMap = new HashMap<>();
 
         // 로그인하지 않은 경우 모두 false 처리
-        if (memberId == null) {
+        if (member == null) {
             for (Long postId : postIds) {
                 likedMap.put(postId, false);
             }
             return likedMap;
         }
-
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new CustomException(MEMBER_NOT_EXIST));
 
         List<PostLike> likedPosts = postLikeRepository.findByPostIdInAndMember(postIds, member);
 
@@ -122,5 +104,11 @@ public class PostLikeServiceImpl implements PostLikeService {
         }
 
         return likedMap;
+    }
+
+    // 포스트 조회 유틸 메소드
+    private Post getPostOrThrow(Long postId) {
+        return postRepository.findById(postId)
+                .orElseThrow(() -> new CustomException(POST_NOT_FOUND));
     }
 }

--- a/wannago-server/src/main/java/com/wannago/post/service/PostLikeServiceImpl.java
+++ b/wannago-server/src/main/java/com/wannago/post/service/PostLikeServiceImpl.java
@@ -76,45 +76,51 @@ public class PostLikeServiceImpl implements PostLikeService {
                 .orElseThrow(() -> new CustomException(MEMBER_NOT_EXIST));
         return postLikeRepository.existsByPostAndMember(post, member);
     }
-
-    // 전체 게시글에 대한 좋아요 정보 함께 응답
+    // 게시글별 좋아요 수 Map 반환
     @Override
-    public PostsResponse getAllPostsWithLikeInfo(Long memberId) {
-        // 전체 게시글 목록 가져오기
-        List<Post> posts = postRepository.findAll();
-        // 그 게시글들의 ID만 추출해서 리스트 만듦
-        List<Long> postIds = posts.stream().map(Post::getId).toList();
-
-        // 전체 게시글의 좋아요 수 추출한 리스트 생성
+    public Map<Long, Integer> getLikeCountMap(List<Long> postIds) {
         List<PostLikeCount> counts = postLikeRepository.countLikesByPostIds(postIds);
-        // 전체 게시글 ID와 그에 해당하는 좋아요 수를 매핑할 Map 생성
+
         Map<Long, Integer> likeCountMap = new HashMap<>();
-        // 맵에 게시글 id와 좋아요 수 값을 넣음
-        for (PostLikeCount plc : counts) {
-            likeCountMap.put(plc.getPostId(), plc.getLikeCount().intValue());
+        for (PostLikeCount count : counts) {
+            likeCountMap.put(count.getPostId(), count.getLikeCount().intValue());
         }
 
-        // 현재 로그인한 사용자가 전체 게시글에 대하여 좋아요 눌렀는지 여부를 매핑한 map
+        // postIds에 없는 게시글은 기본값 0으로 넣어줌
+        for (Long postId : postIds) {
+            likeCountMap.putIfAbsent(postId, 0);
+        }
+
+        return likeCountMap;
+    }
+
+    // 사용자의 게시글별 좋아요 여부 Map 반환
+    @Override
+    public Map<Long, Boolean> getLikedMap(List<Long> postIds, Long memberId) {
         Map<Long, Boolean> likedMap = new HashMap<>();
-        //로그인한 상태
-        if (memberId != null) {
-            // 사용자 유효성 검증
-            Member member = memberRepository.findById(memberId)
-                    .orElseThrow(() -> new CustomException(MEMBER_NOT_EXIST));
-            // 해당 유저가 좋아요 누른 게시물의 좋아요 객체들의 리스트
-            List<PostLike> likes = postLikeRepository.findByPostIdInAndMember(postIds, member);
-            // likedMap에 사용자 ID와 좋아요 등록 boolean 값을 넣음
-            for (PostLike like : likes) {
-                likedMap.put(like.getPost().getId(), true);
+
+        // 로그인하지 않은 경우 모두 false 처리
+        if (memberId == null) {
+            for (Long postId : postIds) {
+                likedMap.put(postId, false);
             }
+            return likedMap;
         }
-        // 로그인 안 한 상태
-        else {
-            for (Long id : postIds) {
-                likedMap.put(id, false); // 로그인 안했으니 아무것도 누른적 없다고 설정
-            }
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new CustomException(MEMBER_NOT_EXIST));
+
+        List<PostLike> likedPosts = postLikeRepository.findByPostIdInAndMember(postIds, member);
+
+        for (PostLike like : likedPosts) {
+            likedMap.put(like.getPost().getId(), true);
         }
-        // 응답 DTO 리스트로 전달
-        return postMapper.getPostsResponse(posts, likeCountMap, likedMap);
+
+        // 나머지는 false 처리
+        for (Long postId : postIds) {
+            likedMap.putIfAbsent(postId, false);
+        }
+
+        return likedMap;
     }
 }


### PR DESCRIPTION
PostLike에 대하여
- getPostOrThrow유틸 메서드로 중복 제거
- @AuthenticationPrincipal 활용해 멤버 ID 파라미터 제거 및 인증 객체 기반 처리로 일관성 확보