### PR TITLE
refactor: 댓글 유효성 검사 로직을 @Valid 기반으로 변경

### DIFF
--- a/wannago-server/.gitignore
+++ b/wannago-server/.gitignore
@@ -25,6 +25,8 @@ bin/
 out/
 !**/src/main/**/out/
 !**/src/test/**/out/
+.yml
+src/main/resources/application.yml
 
 ### NetBeans ###
 /nbproject/private/
@@ -36,5 +38,3 @@ out/
 ### VS Code ###
 .vscode/
 
-.yml
-src/main/resources/application.yml

--- a/wannago-server/src/main/java/com/wannago/common/exception/CustomErrorCode.java
+++ b/wannago-server/src/main/java/com/wannago/common/exception/CustomErrorCode.java
@@ -15,10 +15,13 @@ public enum CustomErrorCode {
     EMAIL_MISMATCH(HttpStatus.BAD_REQUEST, "M005", "잘못된 이메일입니다."),
 
     // 게시글 P
-    POST_NOT_FOUND(HttpStatus.NOT_FOUND, "P001", "요청하신 게시글을 찾을 수 없습니다.");
+    POST_NOT_FOUND(HttpStatus.NOT_FOUND, "P001", "요청하신 게시글을 찾을 수 없습니다."),
 
+    // 댓글 C
+    COMMENT_EMPTY(HttpStatus.BAD_REQUEST, "C001", "댓글 내용을 입력해주세요."),
+    COMMENT_TOO_LONG(HttpStatus.BAD_REQUEST, "C002", "댓글은 100자 이하로 입력해주세요.");
 
-    // 답변 C
+    // 답변 A
 
 
     // 질문 Q

--- a/wannago-server/src/main/java/com/wannago/post/controller/CommentController.java
+++ b/wannago-server/src/main/java/com/wannago/post/controller/CommentController.java
@@ -1,0 +1,28 @@
+package com.wannago.post.controller;
+
+import com.wannago.member.entity.Member;
+import com.wannago.post.dto.CommentRequest;
+import com.wannago.post.dto.CommentResponse;
+import com.wannago.post.service.CommentService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/post/{postId}/comment")
+public class CommentController {
+
+    private final CommentService commentService;
+
+    // 댓글 작성
+    @PostMapping
+    public ResponseEntity<CommentResponse> addComment(
+            @PathVariable Long postId,
+            @RequestBody CommentRequest req,
+            @AuthenticationPrincipal Member member
+            ){
+        return ResponseEntity.ok(commentService.addComment(postId,req,member));
+    }
+}

--- a/wannago-server/src/main/java/com/wannago/post/dto/CommentRequest.java
+++ b/wannago-server/src/main/java/com/wannago/post/dto/CommentRequest.java
@@ -1,0 +1,14 @@
+package com.wannago.post.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CommentRequest {
+    private String content;
+}

--- a/wannago-server/src/main/java/com/wannago/post/dto/CommentRequest.java
+++ b/wannago-server/src/main/java/com/wannago/post/dto/CommentRequest.java
@@ -1,5 +1,7 @@
 package com.wannago.post.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,5 +12,7 @@ import lombok.Setter;
 @NoArgsConstructor
 @AllArgsConstructor
 public class CommentRequest {
+    @NotBlank(message = "댓글 내용은 비어 있을 수 없습니다.")
+    @Size(max = 100, message = "댓글은 최대 100자까지 입력할 수 있습니다.")
     private String content;
 }

--- a/wannago-server/src/main/java/com/wannago/post/dto/CommentResponse.java
+++ b/wannago-server/src/main/java/com/wannago/post/dto/CommentResponse.java
@@ -1,0 +1,22 @@
+package com.wannago.post.dto;
+
+import com.wannago.post.entity.Comment;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class CommentResponse {
+    private String id;
+    private Long postId;
+    private String parentId;
+    private String author;
+    private String contents;
+    private LocalDateTime createdDate;
+    private LocalDateTime modifiedDate;
+}

--- a/wannago-server/src/main/java/com/wannago/post/entity/Comment.java
+++ b/wannago-server/src/main/java/com/wannago/post/entity/Comment.java
@@ -2,20 +2,28 @@ package com.wannago.post.entity;
 
 import jakarta.persistence.Id;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
+@Getter
 @NoArgsConstructor
 @AllArgsConstructor
-@Document("comment")
+@Builder
+@Document(collection = "comment") //  MongoDB 컬렉션 이름
 public class Comment {
     @Id
-    private Long id;
-    private Long postId;
+    private String id; //  MongoDB는 기본적으로 String 타입의 ObjectId 사용
+    private Long postId; // MySQL(Post)의 id가 Long이기 때문에 맞춰줘야 연동 시 타입 충돌 없음
+    private String parentId; //null = 일반 댓글, not null = 대댓글
     private String author;
     private String contents;
-    private Long parentId;
     private LocalDateTime createdDate;
+    private LocalDateTime modifiedDate;
+    private List<Comment> replies = new ArrayList<>();// 답글 리스트
 }

--- a/wannago-server/src/main/java/com/wannago/post/repository/CommentRepository.java
+++ b/wannago-server/src/main/java/com/wannago/post/repository/CommentRepository.java
@@ -1,0 +1,13 @@
+package com.wannago.post.repository;
+
+import com.wannago.post.entity.Comment;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+import java.util.List;
+
+public interface CommentRepository extends MongoRepository<Comment,String> {
+    // 특정 게시글에 달린 댓글(최상위 댓글)만 작성시간순으로 정렬해서 가져오기
+    List<Comment> findByPostIdAndParentIdIsNullOrderByCreatedDateAsc(String postId);
+    // 특정 댓글에 달린 대댓글들 시간순으로 정렬해서 가져오기
+    List<Comment> findByParentIdOrderByCreatedDateAsc(String parentId);
+}

--- a/wannago-server/src/main/java/com/wannago/post/service/CommentService.java
+++ b/wannago-server/src/main/java/com/wannago/post/service/CommentService.java
@@ -1,0 +1,10 @@
+package com.wannago.post.service;
+
+import com.wannago.member.entity.Member;
+import com.wannago.post.dto.CommentRequest;
+import com.wannago.post.dto.CommentResponse;
+
+public interface CommentService {
+    CommentResponse addComment(Long postId, CommentRequest req, Member member);
+
+}

--- a/wannago-server/src/main/java/com/wannago/post/service/CommentServiceImpl.java
+++ b/wannago-server/src/main/java/com/wannago/post/service/CommentServiceImpl.java
@@ -1,0 +1,41 @@
+package com.wannago.post.service;
+
+import com.wannago.common.exception.CustomErrorCode;
+import com.wannago.common.exception.CustomException;
+import com.wannago.member.entity.Member;
+import com.wannago.post.dto.CommentRequest;
+import com.wannago.post.dto.CommentResponse;
+import com.wannago.post.entity.Comment;
+import com.wannago.post.repository.CommentRepository;
+import com.wannago.post.service.mapper.CommentMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@RequiredArgsConstructor
+@Service
+public class CommentServiceImpl implements CommentService{
+    private final CommentRepository commentRepository;
+    private final CommentMapper commentMapper;
+
+    // 댓글 작성
+    @Override
+    public CommentResponse addComment(Long postId, CommentRequest req, Member member){
+        // 댓글 내용이 빈 값이거나 100자 초과할 경우 예외처리
+        if(req.getContent() == null | req.getContent().isBlank()){ // isBlank -> 스페이스만 입력해도 막고 싶을 경우
+            throw new CustomException(CustomErrorCode.COMMENT_EMPTY);
+        }
+        if(req.getContent().length() > 100){
+            throw new CustomException(CustomErrorCode.COMMENT_TOO_LONG);
+        }
+        // 댓글 객체 생성
+        Comment comment = commentMapper.getComment(postId,req,member);
+        // 댓글 저장
+        commentRepository.save(comment);
+        // 댓글 DTO 반환
+        return commentMapper.getCommentResponse(comment);
+    }
+
+
+}

--- a/wannago-server/src/main/java/com/wannago/post/service/mapper/CommentMapper.java
+++ b/wannago-server/src/main/java/com/wannago/post/service/mapper/CommentMapper.java
@@ -1,0 +1,35 @@
+package com.wannago.post.service.mapper;
+
+import com.wannago.member.entity.Member;
+import com.wannago.post.dto.CommentRequest;
+import com.wannago.post.dto.CommentResponse;
+import com.wannago.post.entity.Comment;
+
+import java.time.LocalDateTime;
+
+public class CommentMapper {
+    // 요청 -> 엔티티로 변환
+    public Comment getComment(Long postId, CommentRequest req, Member member){
+        return Comment.builder()
+                .postId(postId)
+                .parentId(null)
+                .author(member.getLoginId().toString())
+                .contents(req.getContent().trim())
+                .createdDate(LocalDateTime.now())
+                .modifiedDate(LocalDateTime.now())
+                .build();
+    }
+
+    // 엔티티 -> dto로 변환
+    public CommentResponse getCommentResponse(Comment comment){
+        return CommentResponse.builder()
+                .id(comment.getId())
+                .postId(comment.getPostId())
+                .parentId(comment.getParentId())
+                .author(comment.getAuthor())
+                .contents(comment.getContents())
+                .createdDate(comment.getCreatedDate())
+                .modifiedDate(comment.getModifiedDate())
+                .build();
+    }
+}


### PR DESCRIPTION
댓글 요청 DTO(CommentRequest)에 @NotBlank, @Size(100) 유효성 검증 어노테이션을 적용했습니다.
  - 컨트롤러에서 @Valid로 자동 검증되며, 서비스 단에서 별도로 검증하지 않도록 리팩토링했습니다.