### PR TITLE
feat: 댓글 조회 기능 구현

### DIFF
--- a/wannago-server/src/main/java/com/wannago/post/controller/CommentController.java
+++ b/wannago-server/src/main/java/com/wannago/post/controller/CommentController.java
@@ -10,6 +10,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/post/{postId}/comment")
@@ -27,7 +29,7 @@ public class CommentController {
         return ResponseEntity.ok(commentService.addComment(postId,req,member));
     }
 
-    // 답글 작성
+    // 대댓글 작성
     @PostMapping("/{parentCommentId}/reply")
     public ResponseEntity<CommentResponse> addReply(
             @PathVariable Long postId,
@@ -36,6 +38,29 @@ public class CommentController {
             @AuthenticationPrincipal Member member
     ){
         return ResponseEntity.ok(commentService.addReply(postId,parentId,req,member));
+    }
+
+    // 댓글 전체 조회(대댓글 포함)
+    @GetMapping
+    public ResponseEntity<List<CommentResponse>> getAllCommentsWithReplies(
+            @PathVariable Long postId
+    ) {
+        // 모든 댓글 (대댓글 포함)을 가져오기
+        List<CommentResponse> comments = commentService.getAllCommentsWithReplies(postId);
+        // HTTP 200 OK 상태 코드와 함께 댓글 목록을 반환
+        return ResponseEntity.ok(comments);
+    }
+
+    // 특정 댓글의 대댓글만 조회
+    @GetMapping("/{parentCommentId}/reply")
+    public ResponseEntity<List<CommentResponse>> getRepliesForComment(
+            @PathVariable Long postId, // 경로 일관성을 위해 postId를 유지
+            @PathVariable String parentCommentId
+    ) {
+        // 특정 부모 댓글에 속하는 대댓글 목록을 가져오기
+        List<CommentResponse> replies = commentService.getRepliesForComment(parentCommentId);
+        // HTTP 200 OK 상태 코드와 함께 대댓글 목록을 반환합니다.
+        return ResponseEntity.ok(replies);
     }
 
     //댓글 수정

--- a/wannago-server/src/main/java/com/wannago/post/entity/Comment.java
+++ b/wannago-server/src/main/java/com/wannago/post/entity/Comment.java
@@ -25,6 +25,7 @@ public class Comment {
     private String contents;
     private LocalDateTime createdDate;
     private LocalDateTime modifiedDate;
+    @Builder.Default
     private List<Comment> replies = new ArrayList<>();// 답글 리스트
 
     // 댓글 내용 수정용 메서드
@@ -33,7 +34,7 @@ public class Comment {
         this.modifiedDate = LocalDateTime.now();
     }
 
-    // 답글 추가용 메서드
+    // 대댓글 추가용 메서드
     public void addReply(Comment reply) {
         if (this.replies == null) {
             this.replies = new ArrayList<>();

--- a/wannago-server/src/main/java/com/wannago/post/repository/CommentRepository.java
+++ b/wannago-server/src/main/java/com/wannago/post/repository/CommentRepository.java
@@ -6,8 +6,8 @@ import org.springframework.data.mongodb.repository.MongoRepository;
 import java.util.List;
 
 public interface CommentRepository extends MongoRepository<Comment,String> {
-    // 특정 게시글에 달린 댓글(최상위 댓글)만 작성시간순으로 정렬해서 가져오기
-    List<Comment> findByPostIdAndParentIdIsNullOrderByCreatedDateAsc(String postId);
-    // 특정 댓글에 달린 대댓글들 시간순으로 정렬해서 가져오기
-    List<Comment> findByParentIdOrderByCreatedDateAsc(String parentId);
+    // 특정 postId에 속하는 일반 댓글 (parentId가 null)을 생성일 기준 오름차순으로 조회
+    // 내장 구조에서는 parentId로 대댓글을 직접 찾는 메서드는 필요 없음
+    List<Comment> findByPostIdAndParentIdIsNullOrderByCreatedDateAsc(Long postId);
+
 }

--- a/wannago-server/src/main/java/com/wannago/post/service/CommentService.java
+++ b/wannago-server/src/main/java/com/wannago/post/service/CommentService.java
@@ -4,9 +4,12 @@ import com.wannago.member.entity.Member;
 import com.wannago.post.dto.CommentRequest;
 import com.wannago.post.dto.CommentResponse;
 
+import java.util.List;
+
 public interface CommentService {
     CommentResponse addComment(Long postId, CommentRequest commentRequest, Member member);
     CommentResponse updateComment(String commentId,CommentRequest commentRequest, Member member);
     CommentResponse addReply(Long postId, String parentId, CommentRequest commentRequest, Member member);
-
+    List<CommentResponse> getAllCommentsWithReplies(Long postId);
+    List<CommentResponse> getRepliesForComment(String parentCommentId);
 }

--- a/wannago-server/src/main/java/com/wannago/post/service/CommentServiceImpl.java
+++ b/wannago-server/src/main/java/com/wannago/post/service/CommentServiceImpl.java
@@ -12,6 +12,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Service
@@ -32,31 +35,60 @@ public class CommentServiceImpl implements CommentService{
         return commentMapper.getCommentResponse(comment);
     }
 
-    // 답글 작성: 부모 댓글의 replies 리스트에 직접 추가
+    // 대댓글 작성: 부모 댓글의 replies 리스트에 직접 추가
     @Override
     public CommentResponse addReply(Long postId, String parentId, CommentRequest commentRequest, Member member) {
         // 부모 댓글을 찾아 유효성 검증
         Comment parentComment = getCommentOrThrow(parentId);
 
-        // 답글 객체를 생성하여 부모 Document의 Sub-document로 만들기
-        Comment reply = commentMapper.getComment(
+        // 대댓글 객체를 생성하여 부모 Document의 Sub-document로 만들기
+        Comment reply = commentMapper.getReply(
                 parentComment.getPostId(), // 부모 댓글의 postId를 사용
+                parentId,
                 commentRequest,
                 member
         );
 
-        // 부모 댓글의 replies 리스트에 새로 생성된 답글을 추가
+        // 부모 댓글의 replies 리스트에 새로 생성된 대댓글을 추가
         parentComment.addReply(reply);
 
         // 변경된 부모 댓글 문서를 저장 -> MongoDB는 내장된 배열을 업데이트할 때 전체 문서를 저장
         commentRepository.save(parentComment);
 
-        // 답글 DTO 반환 (reply는 DB에 독립적으로 저장되지 않은 객체)
+        // 대댓글 DTO 반환 (reply는 DB에 독립적으로 저장되지 않은 객체)
         return commentMapper.getCommentResponse(reply);
     }
 
+     // 특정 게시글에 대한 모든 댓글과 대댓글을 함께 조회
+    // MongoDB의 내장(Embedded) 구조에서는 일반 댓글 문서를 조회하면 그 안에 모든 대댓글이 이미 포함되어 있음
+    @Override
+    public List<CommentResponse> getAllCommentsWithReplies(Long postId) {
+        // 해당 postId에 속하는 모든 일반 댓글을 조회
+        List<Comment> parentComments = commentRepository.findByPostIdAndParentIdIsNullOrderByCreatedDateAsc(postId);
+
+        // 조회된 부모 댓글들을 CommentResponse DTO로 변환, 내장된 replies 리스트의 대댓글들도 CommentResponse DTO로 변환하여 포함
+        return parentComments.stream()
+                .map(commentMapper::getCommentResponseWithReplies)
+                .collect(Collectors.toList());
+    }
+
+    // 특정 댓글의 대댓글만 조회
+    @Override
+    public List<CommentResponse> getRepliesForComment(String parentCommentId) {
+        Comment parentComment = getCommentOrThrow(parentCommentId);
+        // 대댓글 리스트가 null이 아니라면 반환
+        if (parentComment.getReplies() == null || parentComment.getReplies().isEmpty()) {
+            return List.of();
+        }
+        // 대댓글 리스트가 null이라면 가져오기
+        return parentComment.getReplies().stream()
+                .map(commentMapper::getCommentResponseWithReplies)
+                .sorted(Comparator.comparing(CommentResponse::getCreatedDate))
+                .collect(Collectors.toList());
+    }
 
     // 댓글 수정
+    @Override
     public CommentResponse updateComment(String commentId,CommentRequest commentRequest, Member member){
         // 댓글 찾기 및 유효성 검증
         Comment comment = getCommentOrThrow(commentId);

--- a/wannago-server/src/main/java/com/wannago/post/service/mapper/CommentMapper.java
+++ b/wannago-server/src/main/java/com/wannago/post/service/mapper/CommentMapper.java
@@ -7,14 +7,17 @@ import com.wannago.post.entity.Comment;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Component
 public class CommentMapper {
-    // 요청 -> 엔티티로 변환
+    // 요청 -> 엔티티로 변환 (일반 댓글용)
     public Comment getComment(Long postId, CommentRequest req, Member member){
         return Comment.builder()
                 .postId(postId)
-                .parentId(null)
+                .parentId(null) // 댓글은 parentId가 null
                 .author(member.getLoginId().toString())
                 .contents(req.getContent().trim())
                 .createdDate(LocalDateTime.now())
@@ -22,16 +25,48 @@ public class CommentMapper {
                 .build();
     }
 
-    // 엔티티 -> dto로 변환
+    // 요청 -> 엔티티로 변환 (대댓글용 - parentId를 받음)
+    public Comment getReply(Long postId, String parentId, CommentRequest req, Member member){
+        return Comment.builder()
+                .postId(postId)
+                .parentId(parentId) // 대댓글은 parentId가 설정됨
+                .author(member.getLoginId().toString())
+                .contents(req.getContent().trim())
+                .createdDate(LocalDateTime.now())
+                .modifiedDate(LocalDateTime.now())
+                .build();
+    }
+
+    // Comment 엔티티 -> DTO로 변환 (대댓글 리스트 없이)
     public CommentResponse getCommentResponse(Comment comment){
         return CommentResponse.builder()
                 .id(comment.getId())
                 .postId(comment.getPostId())
-                .parentId(comment.getParentId())
+                .parentId(comment.getParentId()) // 대댓글은 parentId가 설정됨
                 .author(comment.getAuthor())
                 .contents(comment.getContents())
                 .createdDate(comment.getCreatedDate())
                 .modifiedDate(comment.getModifiedDate())
                 .build();
+    }
+
+    // 재귀를 사용하여 Comment 엔티티 객체의 트리 구조(댓글과 그에 딸린 모든 대댓글들)를 CommentResponse DTO 객체의 트리 구조로 변환
+    //  Comment 객체가 최상위 댓글이든 대댓글이든 상관없이, 그 Comment 객체와 그 안에 포함된 모든 하위 replies들을 CommentResponse DTO로 변환
+    public CommentResponse getCommentResponseWithReplies(Comment comment) {
+        // 댓글 dto로 변환
+        CommentResponse commentResponse = getCommentResponse(comment);
+        // 대댓글이 null이 아니라면 => 재귀 호출(대댓글 dto 변환) 시작
+        if (comment.getReplies() != null && !comment.getReplies().isEmpty()) {
+            List<CommentResponse> replyResponses =
+                    // 각 대댓글(Comment 객체)에 대해 재귀 호출!
+                    comment.getReplies().stream().map(this::getCommentResponseWithReplies)
+                            // 작성 시간순으로 대댓글 정렬
+                    .sorted(Comparator.comparing(CommentResponse::getCreatedDate))
+                            // 리스트로 변환
+                    .collect(Collectors.toList());
+            commentResponse.setReplies(replyResponses); // 현재 댓글 DTO에 변환된 대댓글 리스트 설정
+        }
+        // else => 대댓글이 null이라면 댓글만 dto로 변환한채로 반환
+        return commentResponse;
     }
 }


### PR DESCRIPTION
### ✅변경 사항

**답글 -> 대댓글로 명칭 변경**

**재귀적 DTO 변환을 통한 계층적 답글 조회:**

> CommentMapper에 toCommentResponseWithReplies 헬퍼 메서드를 추가하여 Comment 엔티티의 replies 리스트(내장된 답글들)를 재귀적으로 CommentResponse DTO로 변환하도록 구현했습니다.
> 
> 이로 인해 하나의 쿼리로 댓글과 모든 하위 답글(대댓글의 대댓글 포함)을 함께 조회하고 클라이언트에게 계층 구조로 제공할 수 있습니다.

**특정 댓글의 답글만 조회하는 API 추가:**

> GET /post/{postId}/comment/{parentCommentId}/reply 엔드포인트를 추가하여 특정 댓글에 속하는 답글 목록만을 효율적으로 조회할 수 있도록 했습니다.

### ✅기술적 특징

- MongoDB의 내장(Embedded) 문서 모델의 장점을 활용하여, 단일 DB 쿼리로 부모 댓글과 모든 자식 답글을 한 번에 가져와 조회 성능을 최적화합니다.
- 애플리케이션 계층에서 재귀 변환 로직을 통해 엔티티의 중첩 구조를 DTO의 중첩 구조로 매핑합니다.
- 성능 향상: 기존의 parentId 기반 참조 방식 대비, 네트워크 왕복 횟수가 줄어들어 조회 성능이 향상됩니다.
- 코드 응집성: 변환 로직이 CommentMapper로 이동하여 서비스 계층의 비즈니스 로직과 변환 로직이 분리되었습니다.