### PR TITLE
마이페이지 qna 분리

### DIFF
--- a/wannago-client/package-lock.json
+++ b/wannago-client/package-lock.json
@@ -8,8 +8,10 @@
       "name": "wannago-client",
       "version": "0.0.0",
       "dependencies": {
+        "axios": "^1.10.0",
         "react": "^19.1.0",
-        "react-dom": "^19.1.0"
+        "react-dom": "^19.1.0",
+        "react-router-dom": "^7.6.3"
       },
       "devDependencies": {
         "@eslint/js": "^9.29.0",
@@ -1480,6 +1482,23 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.10.0.tgz",
+      "integrity": "sha512-/1xYAC4MP/HEG+3duIhFr4ZQXR4sQXOIe+o6sdqzeykGLx6Upp/1p8MHqhINOvGeP7xyNHe7tsiJByc4SSVUxw==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -1529,6 +1548,19 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/callsites": {
@@ -1599,6 +1631,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -1612,6 +1656,15 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -1660,12 +1713,80 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.175",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.175.tgz",
       "integrity": "sha512-Nqpef9mOVo7pZfl9NIUhj7tgtRTsMzCzRTJDP1ccim4Wb4YHOz3Le87uxeZq68OCNwau2iQ/X7UwdAZ3ReOkmg==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.25.5",
@@ -1996,6 +2117,42 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.3.tgz",
+      "integrity": "sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -2011,6 +2168,15 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -2019,6 +2185,43 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/glob-parent": {
@@ -2047,6 +2250,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -2055,6 +2270,45 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/ignore": {
@@ -2246,6 +2500,36 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/minimatch": {
@@ -2443,6 +2727,12 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -2482,6 +2772,44 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.6.3.tgz",
+      "integrity": "sha512-zf45LZp5skDC6I3jDLXQUu0u26jtuP4lEGbc7BbdyxenBN1vJSTA18czM2D+h5qyMBuMrD+9uB+mU37HIoKGRA==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.6.3.tgz",
+      "integrity": "sha512-DiWJm9qdUAmiJrVWaeJdu4TKu13+iB/8IEi0EW/XgaHCjW/vWGrwzup0GVvaMteuZjKnh5bEvJP/K0MDnzawHw==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.6.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
       }
     },
     "node_modules/resolve-from": {
@@ -2549,6 +2877,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/wannago-client/package.json
+++ b/wannago-client/package.json
@@ -10,8 +10,10 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "axios": "^1.10.0",
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "react-router-dom": "^7.6.3"
   },
   "devDependencies": {
     "@eslint/js": "^9.29.0",

--- a/wannago-client/src/api/mypage.js
+++ b/wannago-client/src/api/mypage.js
@@ -1,11 +1,39 @@
 import axios from 'axios';
 
+// 내가 쓴 글 조회
 export const fetchMyPosts = async (loginId) => {
-  const response = await axios.get(`/api/mypage/posts`, { params: { loginId } });
-  return response.data;
+  try {
+    const response = await axios.get(`/api/mypage/posts`, {
+      params: { loginId },
+    });
+
+    if (response.status === 200) {
+      return response.data;
+    } else {
+      console.error('내 글 조회 실패: 응답 상태 코드', response.status);
+      return null;
+    }
+  } catch (error) {
+    console.error('내 글 조회 중 에러 발생:', error);
+    return null;
+  }
 };
 
+// 내가 작성한 질문(QnA) 조회
 export const fetchMyQnas = async (loginId) => {
-  const response = await axios.get(`/api/mypage/qnas`, { params: { loginId } });
-  return response.data;
+  try {
+    const response = await axios.get(`/api/mypage/qnas`, {
+      params: { loginId },
+    });
+
+    if (response.status === 200) {
+      return response.data;
+    } else {
+      console.error('내 질문 목록 조회 실패: 응답 상태 코드', response.status);
+      return null;
+    }
+  } catch (error) {
+    console.error('내 질문 목록 조회 중 에러 발생:', error);
+    return null;
+  }
 };

--- a/wannago-client/src/api/mypage.js
+++ b/wannago-client/src/api/mypage.js
@@ -1,0 +1,11 @@
+import axios from 'axios';
+
+export const fetchMyPosts = async (loginId) => {
+  const response = await axios.get(`/api/mypage/posts`, { params: { loginId } });
+  return response.data;
+};
+
+export const fetchMyQnas = async (loginId) => {
+  const response = await axios.get(`/api/mypage/qnas`, { params: { loginId } });
+  return response.data;
+};

--- a/wannago-client/src/pages/MyPostPage.jsx
+++ b/wannago-client/src/pages/MyPostPage.jsx
@@ -1,104 +1,84 @@
 import '../assets/css/qna-list.css';
 import DefaultLayout from '../layouts/DefatulLayout';
 import QnaItem from '../components/QnaItem';
-import { useParams } from 'react-router';
 import PostItem from '../components/PostItem';
+import { useParams } from 'react-router';
+import { useEffect, useState } from 'react';
+import { fetchMyPosts, fetchMyQnas } from '../api/mypage'; // 새로 추가
+import { useNavigate } from 'react-router-dom';
 
-const posts = [
-  {
-    title : "여행 계획 세우기 좋은 앱 추천해주세요!",
-    createdDate : "2025.06.26",
-    author : "김여행",
-    contents : "안녕하세요! 이번 여름휴가 때 제주도로 여행을 가려고 하는데, 여행 계획 세우기 좋은 앱이나 웹사이트가 있을까요? 숙소 예약부터 맛집, 관광지 정보까지 한 번에 볼 수 있으면 좋겠어요. 추천 부탁드립니다!",
-    tags : ["여행", "휴가", "제주도"],
-    likeCount : 5
-  },
-  {
-    title : "제주도 동쪽 맛집 추천 부탁드려요!",
-    createdDate : "2025.06.26",
-    author : "박미식",
-    contents : "제주도 동쪽으로 여행 가는데, 현지인 추천 맛집이 궁금해요! 특히 해산물이나 흑돼지 맛집 위주로 알려주시면 감사하겠습니다. 웨이팅이 길어도 맛있으면 괜찮아요!",
-    tags : ["여행", "동쪽", "맛집"],
-    likeCount : 5
-  },
-  {
-    title : "제주도에서 스쿠버 다이빙 체험할 수 있는 곳 추천!",
-    createdDate : "2025.06.26",
-    author : "최액티",
-    contents : "스쿠버 다이빙을 한 번도 해본 적 없는데, 제주도에서 초보자도 쉽게 체험할 수 있는 곳이 있을까요? 장비 대여나 강습 포함된 패키지로 추천해주시면 좋겠어요. 바다 풍경이 예쁜 곳이면 더 좋고요!",
-    tags : ["액티비티", "스쿠버다이빙", "제주도"],
-    likeCount : 5
-  },
-  {
-    title : "제주도 서쪽 가볼 만한 숨은 명소 알려주세요!",
-    createdDate : "2025.06.26",
-    author : "이지도",
-    isAccepted : true,
-    contents : "제주도 서쪽으로 여행 가는데, 너무 유명한 곳 말고 현지인만 아는 숨은 명소나 예쁜 카페, 조용한 해변 같은 곳이 있을까요? 사진 찍기 좋은 곳이면 더 환영입니다!",
-    tags : ["여행", "휴가", "서쪽"],
-    likeCount : 5
-  }
-];
+function MyPostPage(){
+  const navigate = useNavigate();
 
-const Qnas = [
-  {
-    title : "여행 계획 세우기 좋은 앱 추천해주세요!",
-    createdDate : "2025.06.26",
-    author : "김여행",
-    isAccepted : false,
-    contents : "안녕하세요! 이번 여름휴가 때 제주도로 여행을 가려고 하는데, 여행 계획 세우기 좋은 앱이나 웹사이트가 있을까요? 숙소 예약부터 맛집, 관광지 정보까지 한 번에 볼 수 있으면 좋겠어요. 추천 부탁드립니다!"
-  },
-  {
-    title : "제주도 동쪽 맛집 추천 부탁드려요!",
-    createdDate : "2025.06.26",
-    author : "박미식",
-    isAccepted : false,
-    contents : "제주도 동쪽으로 여행 가는데, 현지인 추천 맛집이 궁금해요! 특히 해산물이나 흑돼지 맛집 위주로 알려주시면 감사하겠습니다. 웨이팅이 길어도 맛있으면 괜찮아요!"
-  },
-  {
-    title : "제주도에서 스쿠버 다이빙 체험할 수 있는 곳 추천!",
-    createdDate : "2025.06.26",
-    author : "최액티",
-    isAccepted : true,
-    contents : "스쿠버 다이빙을 한 번도 해본 적 없는데, 제주도에서 초보자도 쉽게 체험할 수 있는 곳이 있을까요? 장비 대여나 강습 포함된 패키지로 추천해주시면 좋겠어요. 바다 풍경이 예쁜 곳이면 더 좋고요!"
-  },
-  {
-    title : "제주도 서쪽 가볼 만한 숨은 명소 알려주세요!",
-    createdDate : "2025.06.26",
-    author : "이지도",
-    isAccepted : true,
-    contents : "제주도 서쪽으로 여행 가는데, 너무 유명한 곳 말고 현지인만 아는 숨은 명소나 예쁜 카페, 조용한 해변 같은 곳이 있을까요? 사진 찍기 좋은 곳이면 더 환영입니다!"
-  }
-];
+  // ✅ 1. 로그인 여부 확인
+  const loginId = localStorage.getItem("loginId");
 
-const getList = (tab) => {
+
+
+  useEffect(() => {
+    if (!loginId) {
+      alert("로그인이 필요합니다.");
+      navigate("/login");  // 로그인 안 했으면 로그인 페이지로 강제 이동
+    }
+  }, []);
+
+  const { tab } = useParams();
+  const [postList, setPostList] = useState([]);
+  const [qnaList, setQnaList] = useState([]);
+
+  useEffect(() => {
+    const loadData = async () => {
+      try {
+        if(tab === 'post') {
+          const posts = await fetchMyPosts(loginId);
+          setPostList(posts);
+        } else if(tab === 'qna') {
+          const qnas = await fetchMyQnas(loginId);
+          setQnaList(qnas);
+        }
+      } catch (err) {
+        console.error("마이페이지 데이터 로딩 실패", err);
+      }
+    };
+    loadData();
+  }, [tab]);
+
+  const categories = [
+    { name: "나의 여행", tab: "post" },
+    { name: "나의 질문", tab: "qna" }
+  ];
+
+  const selectedCategory = categories.find(category => category.tab === tab)?.name;
+
+  const getList = () => {
   if(tab === 'post') {
-      return (
-        <section className="qna-list-section">
-          { posts.map((post, idx) => <PostItem key={idx} post={post}/>)} {/* QnaListFrame -> PostListFrame으로 변경 */}
-        </section>
+    return (
+      <section className="qna-list-section">
+        {Array.isArray(postList) ? (
+          postList.map((post, idx) => (
+            <PostItem key={idx} post={post} />
+          ))
+        ) : (
+          <p>게시글을 불러올 수 없습니다.</p>
+        )}
+      </section>
     );
   } else if(tab === 'qna') {
     return (
       <section className="qna-list-section">
-          { Qnas.map((qna, idx) => <QnaItem key={idx} qna={qna}/>)}
-        </section>
+        {Array.isArray(qnaList) ? (
+          qnaList.map((qna, idx) => (
+            <QnaItem key={idx} qna={qna} />
+          ))
+        ) : (
+          <p>질문 목록을 불러올 수 없습니다.</p>
+        )}
+      </section>
     );
   }
-
   return null;
-}
+};
 
-const categories = [
-    { name: "나의 여행", tab: "post"},
-    { name: "나의 질문", tab: "qna"}
-];
-
-function MyPostPage(){
-  const { tab } = useParams();
-  const selectedCategory = categories.find(category => category.tab === tab).name;
-  
-  
   return (
     <DefaultLayout>
       <div className="qna-page-container">
@@ -111,13 +91,13 @@ function MyPostPage(){
               key={category.name} 
               className={`menu-item ${selectedCategory === category.name ? "selected" : ""}`}
             >
-              <a href={`/my/${category.tab}`}>{category.name}</a> {/* 실제 앱에서는 라우팅 링크가 될 수 있습니다. */}
+              <a href={`/my/${category.tab}`}>{category.name}</a>
             </div>
           ))}
         </nav>
 
-        {getList(tab)}
-        
+        {getList()}
+
         <nav className="pagination"> 
           <ul className="pagination-list">
             <li className="pagination-page selected"><a href="#">1</a></li>

--- a/wannago-server/src/main/java/com/wannago/post/controller/MyPageController.java
+++ b/wannago-server/src/main/java/com/wannago/post/controller/MyPageController.java
@@ -1,0 +1,29 @@
+package com.wannago.post.controller;
+
+import com.wannago.post.dto.PostResponse;
+import com.wannago.post.service.PostService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class MyPageController {
+
+    private final PostService postService;
+
+     // 내가 쓴 게시글 조회
+    @GetMapping("/posts")
+    public ResponseEntity<List<PostResponse>> getMyPosts(@RequestParam String loginId) {
+        List<PostResponse> posts = postService.getMyPosts(loginId);
+        return ResponseEntity.ok(posts);
+    }
+    // 내가 쓴 질문 목록 조회
+    @GetMapping("/qnas")
+    public ResponseEntity<List<PostResponse>> getMyQnas(@RequestParam String loginId) {
+        List<PostResponse> qnas = postService.getMyQnaList(loginId);
+        return ResponseEntity.ok(qnas);
+    }
+}

--- a/wannago-server/src/main/java/com/wannago/post/controller/MyPageController.java
+++ b/wannago-server/src/main/java/com/wannago/post/controller/MyPageController.java
@@ -1,4 +1,6 @@
 package com.wannago.post.controller;
+// import org.springframework.security.core.annotation.AuthenticationPrincipal; 
+// 추후에 @AuthenticationPrincipal Member member 대체
 
 import com.wannago.post.dto.PostResponse;
 import com.wannago.post.service.PostService;
@@ -13,17 +15,19 @@ import java.util.List;
 public class MyPageController {
 
     private final PostService postService;
-
-     // 내가 쓴 게시글 조회
     @GetMapping("/posts")
     public ResponseEntity<List<PostResponse>> getMyPosts(@RequestParam String loginId) {
         List<PostResponse> posts = postService.getMyPosts(loginId);
         return ResponseEntity.ok(posts);
     }
-    // 내가 쓴 질문 목록 조회
-    @GetMapping("/qnas")
-    public ResponseEntity<List<PostResponse>> getMyQnas(@RequestParam String loginId) {
-        List<PostResponse> qnas = postService.getMyQnaList(loginId);
-        return ResponseEntity.ok(qnas);
-    }
+
+
+
+     // 내가 쓴 게시글 조회
+//     @GetMapping("/posts")
+//     public ResponseEntity<List<PostResponse>> getMyPosts(@AuthenticationPrincipal Member member) {
+//     List<PostResponse> posts = postService.getMyPosts(member.getLoginId());
+//     return ResponseEntity.ok(posts);
+// } 추후에 @AuthenticationPrincipal Member member 로 대체할 코드
+
 }

--- a/wannago-server/src/main/java/com/wannago/post/controller/MyQnaController.java
+++ b/wannago-server/src/main/java/com/wannago/post/controller/MyQnaController.java
@@ -1,0 +1,26 @@
+package com.wannago.qna.controller;
+
+import com.wannago.member.entity.Member;
+import com.wannago.qna.dto.AskResponse;
+import com.wannago.qna.service.AskService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/mypage")
+public class MyQnaController {
+
+    private final AskService askService;
+
+    // 내가 쓴 질문 목록 조회
+    @GetMapping("/qnas")
+    public ResponseEntity<List<AskResponse>> getMyQnas(@AuthenticationPrincipal Member member) {
+        List<AskResponse> qnas = askService.getQnasByMember(member);
+        return ResponseEntity.ok(qnas);
+    }
+}

--- a/wannago-server/src/main/java/com/wannago/post/dto/MyAskResponse.java
+++ b/wannago-server/src/main/java/com/wannago/post/dto/MyAskResponse.java
@@ -1,0 +1,27 @@
+package com.wannago.qna.dto;
+
+import com.wannago.qna.entity.Ask;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class AskResponse {
+    private Long id;
+    private String category;
+    private String title;
+    private String content;
+    private boolean isAccepted;
+    private LocalDateTime createdDate;
+
+    public static AskResponse from(Ask ask) {
+        return new AskResponse(
+                ask.getId(),
+                ask.getCategory(),
+                ask.getTitle(),
+                ask.getContent(),
+                ask.isAccepted(),
+                ask.getCreatedDate()
+        );
+    }
+}

--- a/wannago-server/src/main/java/com/wannago/post/dto/PostRequest.java
+++ b/wannago-server/src/main/java/com/wannago/post/dto/PostRequest.java
@@ -1,9 +1,13 @@
 package com.wannago.post.dto;
 
+import java.time.LocalDateTime;
+
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
+@Builder
 @AllArgsConstructor
 public class PostRequest {
     private String title;
@@ -12,4 +16,7 @@ public class PostRequest {
     private boolean isPublic;
     private int likeCount;
     private boolean liked;
+    private Long id;
+    private LocalDateTime createdAt;
+    private boolean isAccepted;
 }

--- a/wannago-server/src/main/java/com/wannago/post/dto/PostResponse.java
+++ b/wannago-server/src/main/java/com/wannago/post/dto/PostResponse.java
@@ -1,12 +1,18 @@
 package com.wannago.post.dto;
 
+import java.time.LocalDateTime;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.Setter;
+import lombok.NoArgsConstructor;
 
 
 @Getter
+@Setter
 @Builder
+@NoArgsConstructor
 @AllArgsConstructor
 public class PostResponse {
     private Long id;
@@ -16,4 +22,6 @@ public class PostResponse {
     private boolean isPublic;
     private int likeCount;
     private boolean liked;
+    private LocalDateTime createdAt;
+     private boolean isAccepted;
 }

--- a/wannago-server/src/main/java/com/wannago/post/entity/Ask.java
+++ b/wannago-server/src/main/java/com/wannago/post/entity/Ask.java
@@ -1,0 +1,49 @@
+package com.wannago.qna.entity;
+
+import com.wannago.member.entity.Member;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+public class Ask {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "ask_id")
+    private Long id;
+
+    @Column(nullable = false)
+    private String category;  // 질문 카테고리
+
+    @Column(nullable = false)
+    private String title;     // 질문 제목
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String content;   // 질문 내용
+
+    @Column(nullable = false)
+    private boolean isAccepted; // 채택 여부
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;    // 작성자 - 로그인 정보
+
+    @Column(nullable = false)
+    private String author;    // 작성자 loginId 저장용
+
+    @CreationTimestamp
+    @Column(name = "created_date", updatable = false)
+    private LocalDateTime createdDate;  // 작성일
+
+    @UpdateTimestamp
+    @Column(name = "updated_date")
+    private LocalDateTime updatedDate;  // 수정일
+}

--- a/wannago-server/src/main/java/com/wannago/post/service/MyAskService.java
+++ b/wannago-server/src/main/java/com/wannago/post/service/MyAskService.java
@@ -1,0 +1,10 @@
+package com.wannago.qna.service;
+
+import com.wannago.member.entity.Member;
+import com.wannago.qna.dto.AskResponse;
+
+import java.util.List;
+
+public interface AskService {
+    List<AskResponse> getQnasByMember(Member member);
+}

--- a/wannago-server/src/main/java/com/wannago/post/service/MyAskServiceImpl.java
+++ b/wannago-server/src/main/java/com/wannago/post/service/MyAskServiceImpl.java
@@ -1,0 +1,27 @@
+package com.wannago.qna.service;
+
+import com.wannago.member.entity.Member;
+import com.wannago.qna.dto.AskResponse;
+import com.wannago.qna.entity.Ask;
+import com.wannago.qna.mapper.AskMapper;
+import com.wannago.qna.repository.AskRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class AskServiceImpl implements AskService {
+
+    private final AskRepository askRepository;
+    private final AskMapper askMapper;
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<AskResponse> getQnasByMember(Member member) {
+        List<Ask> myQnas = askRepository.findByMember(member);
+        return askMapper.toAskResponseList(myQnas);
+    }
+}

--- a/wannago-server/src/main/java/com/wannago/post/service/PostServiceImpl.java
+++ b/wannago-server/src/main/java/com/wannago/post/service/PostServiceImpl.java
@@ -8,7 +8,6 @@ import com.wannago.post.dto.PostsResponse;
 import com.wannago.post.entity.Post;
 import com.wannago.post.repository.PostRepository;
 import com.wannago.post.service.mapper.PostMapper;
-import com.wannago.qna.entity.Ask;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -47,10 +46,5 @@ public List<PostResponse> getMyPosts(String loginId) {
     return postMapper.toPostSimpleResponseList(myPosts);
 }
 
-@Transactional(readOnly = true)
-public List<PostResponse> getMyQnaList(String loginId) {
-    List<Ask> myQnas = askRepository.findByAuthor(loginId);
-    return postMapper.toAskSimpleResponseList(myQnas);
-}
 
 }

--- a/wannago-server/src/main/java/com/wannago/post/service/PostServiceImpl.java
+++ b/wannago-server/src/main/java/com/wannago/post/service/PostServiceImpl.java
@@ -8,6 +8,8 @@ import com.wannago.post.dto.PostsResponse;
 import com.wannago.post.entity.Post;
 import com.wannago.post.repository.PostRepository;
 import com.wannago.post.service.mapper.PostMapper;
+import com.wannago.qna.entity.Ask;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -39,5 +41,16 @@ public class PostServiceImpl implements PostService {
 
         return postMapper.getPostResponse(post.get());
     }
+@Transactional(readOnly = true)
+public List<PostResponse> getMyPosts(String loginId) {
+    List<Post> myPosts = postRepository.findByAuthor(loginId);
+    return postMapper.toPostSimpleResponseList(myPosts);
+}
+
+@Transactional(readOnly = true)
+public List<PostResponse> getMyQnaList(String loginId) {
+    List<Ask> myQnas = askRepository.findByAuthor(loginId);
+    return postMapper.toAskSimpleResponseList(myQnas);
+}
 
 }

--- a/wannago-server/src/main/java/com/wannago/post/service/mapper/MyAskMapper.java
+++ b/wannago-server/src/main/java/com/wannago/post/service/mapper/MyAskMapper.java
@@ -1,0 +1,20 @@
+package com.wannago.qna.service.mapper;
+
+import com.wannago.qna.dto.AskResponse;
+import com.wannago.qna.entity.Ask;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class AskMapper {
+    public AskResponse toAskResponse(Ask ask) {
+        return AskResponse.from(ask);
+    }
+
+    public List<AskResponse> toAskResponseList(List<Ask> asks) {
+        return asks.stream()
+                .map(this::toAskResponse)
+                .toList();
+    }
+}

--- a/wannago-server/src/main/java/com/wannago/post/service/mapper/PostMapper.java
+++ b/wannago-server/src/main/java/com/wannago/post/service/mapper/PostMapper.java
@@ -69,26 +69,8 @@ public class PostMapper {
                 .collect(Collectors.toList());
     }
 
-    // 마이페이지용 - Ask → PostResponse 변환
-    public PostResponse toAskSimpleResponse(Ask ask) {
-        return PostResponse.builder()
-                .id(ask.getId())
-                .title(ask.getTitle())
-                .createdAt(ask.getCreatedDate())
-                .author(ask.getAuthor())
-                .contents(ask.getContents())
-                .isPublic(false) // 질문에는 공개 여부 없음
-                .likeCount(0)    // 질문에는 좋아요 없음
-                .liked(false)    // 로그인 사용자 기준 좋아요 없음
-                .isAccepted(ask.isAccepted())
-                .build();
-    }
 
-    public List<PostResponse> toAskSimpleResponseList(List<Ask> asks) {
-        return asks.stream()
-                .map(this::toAskSimpleResponse)
-                .collect(Collectors.toList());
-    }
+
     
 }
 

--- a/wannago-server/src/main/java/com/wannago/post/service/mapper/PostMapper.java
+++ b/wannago-server/src/main/java/com/wannago/post/service/mapper/PostMapper.java
@@ -4,10 +4,13 @@ import com.wannago.post.dto.PostRequest;
 import com.wannago.post.dto.PostResponse;
 import com.wannago.post.dto.PostsResponse;
 import com.wannago.post.entity.Post;
+import com.wannago.qna.entity.Ask;
+
 import org.springframework.stereotype.Component;
 
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 @Component
 public class PostMapper {
@@ -46,4 +49,46 @@ public class PostMapper {
                 .liked(liked)
                 .build();
     }
+    // 마이페이지용 - 단순 Post → PostResponse 변환 (제목 + 작성일)
+    public PostResponse toPostSimpleResponse(Post post) {
+        return PostResponse.builder()
+                .id(post.getId())
+                .title(post.getTitle())
+                .createdAt(post.getCreatedDate())
+                .author(post.getAuthor())
+                .contents(post.getContents())
+                .isPublic(post.isPublic())
+                .likeCount(0)
+                .liked(false)
+                .build();
+    }
+
+    public List<PostResponse> toPostSimpleResponseList(List<Post> posts) {
+        return posts.stream()
+                .map(this::toPostSimpleResponse)
+                .collect(Collectors.toList());
+    }
+
+    // 마이페이지용 - Ask → PostResponse 변환
+    public PostResponse toAskSimpleResponse(Ask ask) {
+        return PostResponse.builder()
+                .id(ask.getId())
+                .title(ask.getTitle())
+                .createdAt(ask.getCreatedDate())
+                .author(ask.getAuthor())
+                .contents(ask.getContents())
+                .isPublic(false) // 질문에는 공개 여부 없음
+                .likeCount(0)    // 질문에는 좋아요 없음
+                .liked(false)    // 로그인 사용자 기준 좋아요 없음
+                .isAccepted(ask.isAccepted())
+                .build();
+    }
+
+    public List<PostResponse> toAskSimpleResponseList(List<Ask> asks) {
+        return asks.stream()
+                .map(this::toAskSimpleResponse)
+                .collect(Collectors.toList());
+    }
+    
 }
+


### PR DESCRIPTION
## 작업 개요
- 마이페이지 관련 API 개선
- QnA 기능 분리 및 전용 패키지로 이동

## 주요 변경 사항

### 마이페이지
- 게시글 목록 조회 시 @AuthenticationPrincipal Member로 로그인 사용자 정보 처리
- /api/mypage/posts, /api/mypage/qnas 경로로 API 분리

### QnA 분리
- qna.controller.MyQnaController 생성
- qna.service.AskService, AskServiceImpl 생성 및 이전
- AskMapper, AskResponse 클래스 생성 및 적용
- PostMapper 내부 QnA 관련 메서드 제거

### 기타
- Ask 엔티티에 category, isAccepted, createdDate 필드 추가
- 질문 목록은 최신순 정렬
- 마이페이지에서는 질문 제목, 카테고리, 채택 여부, 작성일 등 기본 정보만 제공