### PR TITLE
feat: 댓글 삭제 기능 구현

### DIFF
--- a/wannago-server/src/main/java/com/wannago/common/exception/CustomErrorCode.java
+++ b/wannago-server/src/main/java/com/wannago/common/exception/CustomErrorCode.java
@@ -23,10 +23,10 @@ public enum CustomErrorCode {
 
     // 댓글 C
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "C001", "요청하신 댓글을 찾을 수 없습니다."),
-    COMMENT_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "C002", "댓글을 수정할 권한이 없습니다.");
+    COMMENT_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "C002", "댓글을 수정할 권한이 없습니다."),
 
     // 답글 R
-
+    INVALID_COMMENT_OPERATION(HttpStatus.BAD_REQUEST, "R001", "대댓글에는 다시 대댓글을 달 수 없습니다."),
    
 
 

--- a/wannago-server/src/main/java/com/wannago/post/controller/CommentController.java
+++ b/wannago-server/src/main/java/com/wannago/post/controller/CommentController.java
@@ -31,7 +31,7 @@ public class CommentController {
     }
 
     // 대댓글 작성
-    @PostMapping("/{parentCommentId}/reply")
+    @PostMapping("/{parentId}/reply")
     public ResponseEntity<CommentResponse> addReply(
             @PathVariable Long postId,
             @PathVariable String parentId,
@@ -48,19 +48,17 @@ public class CommentController {
     ) {
         // 모든 댓글 (대댓글 포함)을 가져오기
         List<CommentResponse> comments = commentService.getAllCommentsWithReplies(postId);
-        // HTTP 200 OK 상태 코드와 함께 댓글 목록을 반환
         return ResponseEntity.ok(comments);
     }
 
     // 특정 댓글의 대댓글만 조회
-    @GetMapping("/{parentCommentId}/reply")
+    @GetMapping("/{parentId}/reply")
     public ResponseEntity<List<CommentResponse>> getRepliesForComment(
             @PathVariable Long postId, // 경로 일관성을 위해 postId를 유지
-            @PathVariable String parentCommentId
+            @PathVariable String parentId
     ) {
         // 특정 부모 댓글에 속하는 대댓글 목록을 가져오기
-        List<CommentResponse> replies = commentService.getRepliesForComment(parentCommentId);
-        // HTTP 200 OK 상태 코드와 함께 대댓글 목록을 반환합니다.
+        List<CommentResponse> replies = commentService.getRepliesForComment(parentId);
         return ResponseEntity.ok(replies);
     }
 
@@ -74,12 +72,13 @@ public class CommentController {
         return ResponseEntity.ok(commentService.updateComment(commentId,commentRequest,member));
     }
 
+
     //댓글 삭제
     @DeleteMapping("/{commentId}")
     public ResponseEntity<Void> deleteComment(
-        @PathVariable Long postId,
-        @PathVariable String commentId,
-        @AuthenticationPrincipal Member member
+            @PathVariable Long postId,
+            @PathVariable String commentId,
+            @AuthenticationPrincipal Member member
     ){
         commentService.deleteComment(postId,commentId,member);
         return ResponseEntity.noContent().build();

--- a/wannago-server/src/main/java/com/wannago/post/controller/CommentController.java
+++ b/wannago-server/src/main/java/com/wannago/post/controller/CommentController.java
@@ -72,4 +72,7 @@ public class CommentController {
     ) {
         return ResponseEntity.ok(commentService.updateComment(commentId,commentRequest,member));
     }
+
+    //댓글 삭제
+
 }

--- a/wannago-server/src/main/java/com/wannago/post/controller/CommentController.java
+++ b/wannago-server/src/main/java/com/wannago/post/controller/CommentController.java
@@ -6,6 +6,7 @@ import com.wannago.post.dto.CommentResponse;
 import com.wannago.post.service.CommentService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -26,7 +27,7 @@ public class CommentController {
             @Valid @RequestBody  CommentRequest req, // 댓글 글자수 제한 및 빈 값 유효성 검증
             @AuthenticationPrincipal Member member
             ){
-        return ResponseEntity.ok(commentService.addComment(postId,req,member));
+        return ResponseEntity.status(HttpStatus.CREATED).body(commentService.addComment(postId,req,member));
     }
 
     // 대댓글 작성
@@ -37,7 +38,7 @@ public class CommentController {
             @Valid @RequestBody  CommentRequest req, // 댓글 글자수 제한 및 빈 값 유효성 검증
             @AuthenticationPrincipal Member member
     ){
-        return ResponseEntity.ok(commentService.addReply(postId,parentId,req,member));
+        return ResponseEntity.status(HttpStatus.CREATED).body(commentService.addReply(postId,parentId,req,member));
     }
 
     // 댓글 전체 조회(대댓글 포함)
@@ -74,5 +75,14 @@ public class CommentController {
     }
 
     //댓글 삭제
+    @DeleteMapping("/{commentId}")
+    public ResponseEntity<Void> deleteComment(
+        @PathVariable Long postId,
+        @PathVariable String commentId,
+        @AuthenticationPrincipal Member member
+    ){
+        commentService.deleteComment(postId,commentId,member);
+        return ResponseEntity.noContent().build();
+    }
 
 }

--- a/wannago-server/src/main/java/com/wannago/post/controller/PostCopyController.java
+++ b/wannago-server/src/main/java/com/wannago/post/controller/PostCopyController.java
@@ -3,6 +3,7 @@ package com.wannago.post.controller;
 import com.wannago.member.entity.Member;
 import com.wannago.post.service.PostCopyService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -22,7 +23,7 @@ public class PostCopyController {
             @AuthenticationPrincipal Member member
     ) {
         Long copiedPostId = postCopyService.copyPost(postId, member);
-        return ResponseEntity.ok(Map.of(
+        return ResponseEntity.status(HttpStatus.CREATED).body(Map.of(
                 "message", "나의 여행에 복사되었습니다.",
                 "copiedPostId", copiedPostId
         ));

--- a/wannago-server/src/main/java/com/wannago/post/service/CommentService.java
+++ b/wannago-server/src/main/java/com/wannago/post/service/CommentService.java
@@ -12,4 +12,5 @@ public interface CommentService {
     CommentResponse addReply(Long postId, String parentId, CommentRequest commentRequest, Member member);
     List<CommentResponse> getAllCommentsWithReplies(Long postId);
     List<CommentResponse> getRepliesForComment(String parentCommentId);
+    void deleteComment(Long postId, String commentId, Member member);
 }

--- a/wannago-server/src/main/java/com/wannago/post/service/CommentServiceImpl.java
+++ b/wannago-server/src/main/java/com/wannago/post/service/CommentServiceImpl.java
@@ -103,10 +103,13 @@ public class CommentServiceImpl implements CommentService{
         // 댓글 DTO 반환
         return commentMapper.getCommentResponse(comment);
     }
+
+    // 댓글 삭제
   
     // 댓글 찾기 및 유효성 검증 유틸 메소드
     private Comment getCommentOrThrow(String commentId) {
         return commentRepository.findById(commentId)
                 .orElseThrow(() -> new CustomException(CustomErrorCode.COMMENT_NOT_FOUND));
     }
+
 }

--- a/wannago-server/src/main/java/com/wannago/post/service/CommentServiceImpl.java
+++ b/wannago-server/src/main/java/com/wannago/post/service/CommentServiceImpl.java
@@ -1,5 +1,4 @@
 package com.wannago.post.service;
-
 import com.wannago.common.exception.CustomErrorCode;
 import com.wannago.common.exception.CustomException;
 import com.wannago.member.entity.Member;
@@ -9,17 +8,20 @@ import com.wannago.post.entity.Comment;
 import com.wannago.post.repository.CommentRepository;
 import com.wannago.post.service.mapper.CommentMapper;
 import jakarta.transaction.Transactional;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
+import org.bson.types.ObjectId;
 import org.springframework.data.mongodb.core.MongoTemplate; // MongoTemplate 임포트
 import org.springframework.data.mongodb.core.query.Criteria; // Criteria 임포트
 import org.springframework.data.mongodb.core.query.Query;     // Query 임포트
 import org.springframework.data.mongodb.core.query.Update;    // Update 임포트
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
 import java.time.LocalDateTime;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
+
 
 @RequiredArgsConstructor
 @Service
@@ -47,11 +49,6 @@ public class CommentServiceImpl implements CommentService{
         // 부모 댓글을 찾아 유효성 검증
         Comment parentComment = getCommentOrThrow(parentId);
 
-        // 부모 댓글 자체가 이미 대댓글이면 그 아래에는 대댓글을 달 수 없도록 하기
-        if (parentComment.getParentId() != null) {
-            throw new CustomException(CustomErrorCode.INVALID_COMMENT_OPERATION);
-        }
-        ///  부모가 댓글인 경우
         // 대댓글 객체를 생성하여 부모 Document의 Sub-document로 만들기
         Comment reply = commentMapper.getReply(
                 parentComment.getPostId(), // 부모 댓글의 postId를 사용
@@ -103,7 +100,7 @@ public class CommentServiceImpl implements CommentService{
     public CommentResponse updateComment(String commentId,CommentRequest commentRequest, Member member){
         // 댓글 찾기 및 유효성 검증
         Comment comment = getCommentOrThrow(commentId);
-        // 로그인한 사용자가 해당 댓글의 작성자인지 유효성 검증
+        // 로그인한 사용자가 해당 댓글의 작성자인지 검증
         validateAuthor(comment,member);
         // 댓글 수정
         comment.updateContent(commentRequest.getContent());
@@ -116,19 +113,26 @@ public class CommentServiceImpl implements CommentService{
     @Override
     @Transactional
     public void deleteComment(Long postId, String commentId, Member member) {
-        // 댓글 유효성 검증
-        Comment comment = getCommentOrThrow(commentId);
-        // 댓글인 경우 (parentId가 null)
-        if (comment.getParentId() == null) {
+        // 댓글 유효성 검증 없이 가져오기(대댓글이라면 무조건 예외뜨므로)
+        Optional<Comment> comment = commentRepository.findById(commentId);
+
+        /// 댓글인 경우 (parentId가 null)
+        if (comment.isPresent() && comment.get().getParentId() == null) {
             // 작성자 유효성 검증
-            validateAuthor(comment, member);
-            commentRepository.delete(comment); // 내장된 replies도 함께 삭제됨
+            validateAuthor(comment.get(), member);
+            commentRepository.delete(comment.get()); // 내장된 replies도 함께 삭제됨
             return;
         }
-        // 대댓글인 경우: 부모 댓글 문서에서 해당 대댓글만 제거
+        /// 대댓글인 경우: 부모 댓글 문서에서 해당 대댓글만 제거
+        // String을 mongodb 쿼리에서 읽을 수 있게 ObjectId로 직접 변환해주기
+        ObjectId commentObjectId = new ObjectId(commentId);
+
+        // postId가 1이고, replies 배열 속 id가 ~인 요소를 가진 Comment 문서(최;상위 댓글)를 찾아라
+        /// 로직에선 id여도 몽고 db에서 조회하면 _id로 나오기 때문에 이거에 맞춰야 함
         Query query = new Query(Criteria.where("postId").is(postId)
-                .and("replies.id").is(commentId));
+                .and("replies._id").is(commentObjectId));
         Comment parentComment = mongoTemplate.findOne(query, Comment.class);
+        // 부모 댓글을 찾을 수 없는 경우
         if (parentComment == null) {
             throw new CustomException(CustomErrorCode.COMMENT_NOT_FOUND);
         }
@@ -136,7 +140,7 @@ public class CommentServiceImpl implements CommentService{
         Comment reply = findCommentInTreeById(parentComment, commentId);
         validateAuthor(reply, member);
         // 실제 삭제 수행
-        Update update = new Update().pull("replies", Query.query(Criteria.where("id").is(commentId)));
+        Update update = new Update().pull("replies", Query.query(Criteria.where("_id").is(commentId)));
         mongoTemplate.updateFirst(query, update, Comment.class);
     }
 
@@ -155,6 +159,7 @@ public class CommentServiceImpl implements CommentService{
         }
         return null;
     }
+
 
     // 댓글 찾기 및 유효성 검증 유틸 메소드
     private Comment getCommentOrThrow(String commentId) {

--- a/wannago-server/src/main/java/com/wannago/post/service/mapper/CommentMapper.java
+++ b/wannago-server/src/main/java/com/wannago/post/service/mapper/CommentMapper.java
@@ -4,6 +4,7 @@ import com.wannago.member.entity.Member;
 import com.wannago.post.dto.CommentRequest;
 import com.wannago.post.dto.CommentResponse;
 import com.wannago.post.entity.Comment;
+import org.bson.types.ObjectId;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
@@ -25,9 +26,10 @@ public class CommentMapper {
                 .build();
     }
 
-    // 요청 -> 엔티티로 변환 (대댓글용 - parentId를 받음)
+    // 요청 -> 대댓글 엔티티로 변환 (대댓글용 - parentId를 받음)
     public Comment getReply(Long postId, String parentId, CommentRequest req, Member member){
         return Comment.builder()
+                .id(new ObjectId().toString())
                 .postId(postId)
                 .parentId(parentId) // 대댓글은 parentId가 설정됨
                 .author(member.getLoginId().toString())


### PR DESCRIPTION
### 변경 사항
1. 댓글과 대댓글 삭제 로직을 하나의 메서드로 통합하여 처리 흐름을 일관되게 정리했습니다.
2. 최상위 댓글인 경우: 해당 댓글 문서를 직접 삭제 → 내장된 대댓글도 함께 제거됨
3. 대댓글인 경우: 부모 댓글의 replies 배열에서 $pull 연산으로 특정 대댓글만 제거
4. 삭제 전 작성자 검증 로직을 공통 메서드로 분리하여 중복 제거 및 가독성 개선

### CRUD별 HTTP 응답 코드 및 ResponseEntity 반환 규칙

> - Create: 생성 성공 시 `ResponseEntity.status(HttpStatus.CREATED).body(...)` 사용
> - Read: 조회 성공 시 `ResponseEntity.ok(...)`로 데이터 반환
> - Update: 수정 성공 시 `ResponseEntity.ok(...)` 또는 `ResponseEntity.noContent().build()` 사용
> - Delete: 삭제 성공 시 `ResponseEntity.noContent().build()` 또는 `ok().build()` 사용