### PR TITLE
마이페이지 내 정보 조회 및 수정 기능 구현

### DIFF
--- a/wannago-server/src/main/java/com/wannago/member/controller/MyPageInfoController.java
+++ b/wannago-server/src/main/java/com/wannago/member/controller/MyPageInfoController.java
@@ -1,0 +1,33 @@
+package com.wannago.member.controller;
+
+import com.wannago.member.dto.MemberInfoResponse;
+import com.wannago.member.dto.MemberUpdateRequest;
+import com.wannago.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/mypage")
+public class MyPageInfoController {
+
+    private final MemberService memberService;
+
+    // 내 정보 조회
+    @GetMapping("/info")
+    public ResponseEntity<MemberInfoResponse> getMyInfo(@RequestParam String loginId) {
+        MemberInfoResponse response = memberService.getMyInfo(loginId);
+        return ResponseEntity.ok(response);
+    }
+
+    // 내 정보 수정
+    @PutMapping("/info")
+    public ResponseEntity<Void> updateMyInfo(
+            @RequestParam String loginId,
+            @RequestBody MemberUpdateRequest request
+    ) {
+        memberService.updateMyInfo(loginId, request);
+        return ResponseEntity.ok().build(); // 아무 응답 없이 200 OK
+    }
+}

--- a/wannago-server/src/main/java/com/wannago/member/dto/MemberInfoResponse.java
+++ b/wannago-server/src/main/java/com/wannago/member/dto/MemberInfoResponse.java
@@ -1,0 +1,19 @@
+package com.wannago.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class MemberInfoResponse {
+    private String loginId;       // 로그인 ID
+    private String name;          // 이름
+    private String email;         // 이메일 (선택 사항)
+    private LocalDateTime createdAt; // 가입일
+}

--- a/wannago-server/src/main/java/com/wannago/member/dto/MemberUpdateRequest.java
+++ b/wannago-server/src/main/java/com/wannago/member/dto/MemberUpdateRequest.java
@@ -1,0 +1,15 @@
+package com.wannago.member.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class MemberUpdateRequest {
+    private String name;
+    private String password;
+    private String passwordConfirm;
+    private String email;
+}

--- a/wannago-server/src/main/java/com/wannago/member/entity/Member.java
+++ b/wannago-server/src/main/java/com/wannago/member/entity/Member.java
@@ -46,4 +46,11 @@ public class Member {
     @UpdateTimestamp
     @Column(name = "modified_date", columnDefinition = "TIMESTAMP", nullable = false)
     private LocalDateTime modifiedDate;
+
+    public void updateInfo(String name, String encodedPassword, String email) {
+    this.name = name;
+    this.password = encodedPassword;
+    this.email = email;
+}
+
 }

--- a/wannago-server/src/main/java/com/wannago/member/service/MemberService.java
+++ b/wannago-server/src/main/java/com/wannago/member/service/MemberService.java
@@ -1,0 +1,12 @@
+package com.wannago.member.service;
+
+import com.wannago.member.dto.MemberInfoResponse;
+import com.wannago.member.dto.MemberUpdateRequest;
+
+public interface MemberService {
+    // 내 정보 조회
+    MemberInfoResponse getMyInfo(String loginId);
+
+    // 내 정보 수정
+    void updateMyInfo(String loginId, MemberUpdateRequest request);
+}

--- a/wannago-server/src/main/java/com/wannago/member/service/MemberServiceImpl.java
+++ b/wannago-server/src/main/java/com/wannago/member/service/MemberServiceImpl.java
@@ -1,0 +1,58 @@
+package com.wannago.member.service;
+
+import com.wannago.common.exception.CustomErrorCode;
+import com.wannago.common.exception.CustomException;
+import com.wannago.member.dto.MemberInfoResponse;
+import com.wannago.member.dto.MemberUpdateRequest;
+import com.wannago.member.entity.Member;
+import com.wannago.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MemberServiceImpl implements MemberService {
+
+    private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    
+    public MemberInfoResponse getMyInfo(String loginId) {
+        Member member = memberRepository.findByLoginId(loginId)
+                .orElseThrow(() -> new CustomException(CustomErrorCode.MEMBER_NOT_EXIST));
+
+        return MemberInfoResponse.builder()
+                .name(member.getName())
+                .email(member.getEmail())
+                .loginId(member.getLoginId())
+                .createdDate(member.getCreatedDate())
+                .build();
+    }
+
+    
+    public void updateMyInfo(String loginId, MemberUpdateRequest request) {
+        Member member = memberRepository.findByLoginId(loginId)
+                .orElseThrow(() -> new CustomException(CustomErrorCode.MEMBER_NOT_EXIST));
+
+        // 예외 처리
+        if (request.getName().isBlank() || request.getPassword().isBlank() || request.getPasswordConfirm().isBlank()) {
+            throw new CustomException(CustomErrorCode.INVALID_INPUT_VALUE);
+        }
+
+        if (!request.getPassword().equals(request.getPasswordConfirm())) {
+            throw new CustomException(CustomErrorCode.PASSWORD_NOT_MATCH);
+        }
+
+        if (request.getPassword().length() < 6 || request.getPassword().length() > 20) {
+            throw new CustomException(CustomErrorCode.INVALID_PASSWORD_LENGTH);
+        }
+
+        // 정보 수정
+        member.updateInfo(
+                request.getName(),
+                passwordEncoder.encode(request.getPassword()),
+                request.getEmail()
+        );
+    }
+}


### PR DESCRIPTION
내 정보 조회 (GET /mypage/info)

-- 로그인한 사용자의 loginId로 이름, 이메일, 가입일, 로그인 ID 조회

-- MemberInfoResponse DTO를 통해 응답

내 정보 수정 (PUT /mypage/info)

-- 이름, 이메일, 비밀번호 수정 가능

-- 비밀번호는 암호화 후 저장

-- 아이디(loginId)와 생년월일(birth)은 수정 불가