### PR TITLE
fix: 게시글 단건 조회 시 회원정보 누락건 수정

### DIFF
--- a/wannago-server/src/main/java/com/wannago/member/jwt/JwtAuthenticationFilter.java
+++ b/wannago-server/src/main/java/com/wannago/member/jwt/JwtAuthenticationFilter.java
@@ -33,14 +33,17 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         String method = request.getMethod();
 
         if ((method.equals("POST") && (path.equals("/join") || path.equals("/login") || path.equals("/reissue")|| path.equals("/check-email"))) ||
-                (method.equals("GET") && (path.startsWith("/posts") || path.startsWith("/post/") ||(path.startsWith("/qna") || path.startsWith("/qna/") || path.equals("/qnas") || path.startsWith("/qnas/"))))) {
-
-
+                (method.equals("GET") && (path.startsWith("/posts") || (path.startsWith("/qna") || path.startsWith("/qna/") || path.equals("/qnas") || path.startsWith("/qnas/"))))) {
             filterChain.doFilter(request, response);
             return; // 토큰 검사 없이 필터 체인 계속
         }
 
         String token = jwtTokenResolver.resolveAccessToken(request);
+
+        if(method.equals("GET") && path.startsWith("/post/") && token == null) {
+            filterChain.doFilter(request, response);
+            return; // 토큰 검사 없이 필터 체인 계속
+        }
 
         // 토큰 없으면 인증 실패 예외 던짐
         if (!StringUtils.hasText(token)) {


### PR DESCRIPTION
토큰정보가 있으면 회원정보를 포함하여 Controller로 전달되고
토큰정보가 없으면 그냥 null로 전달